### PR TITLE
Add GitHub workflow that updates repositories where this repository is used as Git submodule

### DIFF
--- a/.github/workflows/submodule.yml
+++ b/.github/workflows/submodule.yml
@@ -1,0 +1,30 @@
+name: Update repositories where this repository is used as Git submodule.
+
+"on":
+  workflow_dispatch:
+  push:
+    branches: 
+      - master
+
+jobs:
+  usegalaxy-eu_infrastructure-playbook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: usegalaxy-eu/infrastructure-playbook
+          ssh-key: ${{ secrets.USEGALAXY_EU_INFRASTRUCTURE_PLAYBOOK_DEPLOY_KEY }}
+          submodules: false
+
+      - name: Update submodules
+        run: |
+          git submodule update --init --force --recursive --remote files/grafana
+
+      - name: Commit updates
+        run: |
+          set -e
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add files/grafana
+          git commit -m "Update submodule files/grafana" || echo "Submodule files/grafana is already up to date"
+          git push


### PR DESCRIPTION
This PR goes hand in hand with usegalaxy-eu/infrastructure-playbook#1235. That PR adds [usegalaxy-eu/grafana-dashboards](https://github.com/usegalaxy-eu/grafana-dashboards) as a submodule so that the Ansible role `grafana.grafana.grafana` can provision the dashboards from the folder.

This PR automatically updates the submodule version every time a commit arrives in the `master` branch of this repository.

It is part of the colletion of PRs meant to solve usegalaxy-eu/issues#558.