### PR TITLE
Handle dashboard names producing forbidden UNIX paths

### DIFF
--- a/.github/actions/action-grafana-dashboards-export/action.py
+++ b/.github/actions/action-grafana-dashboards-export/action.py
@@ -61,9 +61,19 @@ async def save_dashboard_json(
     ) as response:
         dashboard_json = await response.json()
         metadata = dashboard_json["dashboard"]
-        async with aiofiles.open(
-            f"{path}/{metadata.get('title') or metadata.get('uid')}.json", "w"
-        ) as file:
+
+        file_name = f"{metadata.get('title') or metadata.get('uid')}.json"
+        # forward slashes are not allowed in UNIX paths
+        file_name = file_name.replace("/", "⁄")
+        # NULL bytes are not allowed in UNIX paths
+        file_name = file_name.replace("\x00", "\u200B")
+        # `.` and `..` are reserved names
+        if file_name == ".":
+            file_name = "∘"
+        elif file_name == "..":
+            file_name = "∘∘"
+
+        async with aiofiles.open(f"{path}/{file_name}", "w") as file:
             json_string = json.dumps(dashboard_json, indent=2)
             await file.write(json_string)
 


### PR DESCRIPTION
Replace forbidden characters and reserved names with alternatives in dashboard file names.